### PR TITLE
fix: \Helper\get_echo_function now handles arguments again

### DIFF
--- a/src/helper.php
+++ b/src/helper.php
@@ -30,9 +30,13 @@ function remove_post_prefix_from_keys(array $arr) {
   return $newArray;
 }
 
-function get_echo_function($func_name) {
+function get_echo_function($func_name, $args = null) {
   ob_start();
-  $func_name();
+  if(isset($args)) {
+    $func_name($args);
+  } else {
+    $func_name();
+  }
   $output = ob_get_contents();
   ob_get_clean();
   return $output;


### PR DESCRIPTION
In older versions of the framework get_echo_function handled arguments,
so invocations like:

```php
\Helper\get_echo_function('acf_form', array('id' => 'form'));
```

worked just fine. Without that, things like ACF forms can't be displayed properly.