### PR TITLE
refactor: shorter implementation of strstartswith

### DIFF
--- a/src/helper.php
+++ b/src/helper.php
@@ -70,10 +70,7 @@ function toCssClass($string) {
 
 
 function strstartswith($haystack, $needle) {
-  if  (strpos($haystack,$needle)===0)
-    return true;
-  else
-    return false;
+  return strpos($haystack, $needle) === 0;
 }
 
 function objectToArray($obj) {

--- a/src/helper.php
+++ b/src/helper.php
@@ -70,6 +70,7 @@ function toCssClass($string) {
 
 
 function strstartswith($haystack, $needle) {
+  if (!$needle) return false;
   return strpos($haystack, $needle) === 0;
 }
 


### PR DESCRIPTION
I left the naming intact as it is, but I believe it should be `strStartsWith` according to the some of the others method's names.

I ran across this while figuring out the right place for general helper methods in an app.